### PR TITLE
ICFAR-260 Xconf - Telemetry 2.0 - Bound Profiles Not Showing On Original Telemetry Rules UI Page

### DIFF
--- a/xconf-angular-admin/src/main/webapp/app/xconf/telemetry/telemetrytwoprofile/telemetrytwoprofile.filter.js
+++ b/xconf-angular-admin/src/main/webapp/app/xconf/telemetry/telemetrytwoprofile/telemetrytwoprofile.filter.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  *******************************************************************************/
 angular.module('app.telemetrytwoprofileFilters', [])
-    .filter('profileName', function() {
+    .filter('profileNameTwo', function() {
         return function(profileId, profiles) {
             for(var i = 0; i < profiles.length; i++) {
                 if (profileId === profiles[i].id) {


### PR DESCRIPTION
renamed filter to display `profile name` on `Telementry Rules` 2.0 page